### PR TITLE
refactor: lower-case error messages

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -319,13 +319,13 @@ impl BigTableClient {
             let mut response = self.mutate_rows(request).await?;
             while let Some(part) = response.message().await? {
                 for entry in part.entries {
-                    if let Some(status) = entry.status {
-                        if status.code != 0 {
-                            return Err(BigTableClientError::BigtableWriteError {
-                                status: status.code,
-                                message: status.message,
-                            });
-                        }
+                    if let Some(status) = entry.status
+                        && status.code != 0
+                    {
+                        return Err(BigTableClientError::BigtableWriteError {
+                            status: status.code,
+                            message: status.message,
+                        });
                     }
                 }
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,16 +12,16 @@ pub enum BigTableClientError {
     Grpc(#[from] tonic::Status),
     #[error("gRPC transport error: `{0}`")]
     GrpcTransport(#[from] tonic::transport::Error),
-    #[error("Environment variable error: `{0}`")]
+    #[error("environment variable error: `{0}`")]
     Env(#[from] std::env::VarError),
-    #[error("Invalid URI: `{0}`")]
+    #[error("invalid URI: `{0}`")]
     InvalidUri(#[from] http::uri::InvalidUri),
-    #[error("GCP Auth error: `{0}`")]
+    #[error("gpc auth error: `{0}`")]
     GcpAuth(#[from] gcp_auth::Error),
-    #[error("Bigtable write error: code `{status}`, message: `{message}`")]
+    #[error("nigtable write error: code `{status}`, message: `{message}`")]
     BigtableWriteError { status: i32, message: String },
-    #[error("Header value error: `{0}`")]
+    #[error("header value error: `{0}`")]
     InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
-    #[error("IO error: `{0}`")]
+    #[error("io error: `{0}`")]
     Io(#[from] std::io::Error),
 }


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
