### PR TITLE
refactor: expose the Row instead of the Cell in order to use the key

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -340,7 +340,7 @@ impl BigTableClient {
         table_name: &str,
         keys: Vec<Bytes>,
         filter: Option<RowFilter>,
-    ) -> Result<Vec<Vec<Cell>>> {
+    ) -> Result<Vec<Row>> {
         let start_time = Instant::now();
         let num_keys_requested = keys.len();
         let result = self.multi_get_internal(table_name, keys, filter).await;
@@ -393,7 +393,7 @@ impl BigTableClient {
         table_name: &str,
         keys: Vec<Bytes>,
         filter: Option<RowFilter>,
-    ) -> Result<Vec<Vec<Cell>>> {
+    ) -> Result<Vec<Row>> {
         let request = ReadRowsRequest {
             table_name: self.table_name(table_name),
             rows_limit: keys.len() as i64,
@@ -404,12 +404,7 @@ impl BigTableClient {
             filter,
             ..ReadRowsRequest::default()
         };
-        Ok(self
-            .read_rows(request)
-            .await?
-            .into_iter()
-            .map(|row| row.cells)
-            .collect())
+        self.read_rows(request).await
     }
 
     /// Performs a reverse scan over rows in Bigtable, starting from an upper


### PR DESCRIPTION
# Description of change

This patch exposes `Row` objects (which include both key and cell value) instead of just `Cell` objects when requesting data from BigTable. This enables the KV client to maintain the order of requested keys without requiring additional data fetches. Previously, matching returned data to requested keys required extra lookups; now the key is directly available in each row.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/9542