### PR TITLE
fix(iota-bigtable): add backoff retries for gRPC transient errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,41 +282,41 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -654,6 +668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +691,7 @@ dependencies = [
 name = "iota-bigtable"
 version = "0.1.0"
 dependencies = [
+ "backoff",
  "gcp_auth",
  "http",
  "prometheus",
@@ -886,18 +910,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1041,6 +1068,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1959,6 +2016,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 gcp_auth = "0.12.5"
 http = "1"
 prometheus = "0.14"

--- a/src/client.rs
+++ b/src/client.rs
@@ -314,7 +314,10 @@ impl BigTableClient {
             client
                 .read_rows_internal(request)
                 .await
-                .map_err(BigTableClientError::into_backoff_error)
+                .map_err(|e| match e.is_permantent() {
+                    true => backoff::Error::permanent(e),
+                    false => e.into(),
+                })
         })
         .await
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use backoff::{ExponentialBackoff, backoff::Backoff};
+use backoff::{
+    ExponentialBackoff,
+    backoff::{Backoff, Stop},
+};
 use gcp_auth::{Token, TokenProvider};
 use http::{HeaderValue, Request, Response};
 use prometheus::Registry;
@@ -87,6 +90,31 @@ impl Row {
     }
 }
 
+/// Retry policy for the client.
+#[derive(Debug, Clone)]
+enum BackoffPolicy {
+    /// Never retry.
+    Stop,
+    /// Retry transient errors with exponential backoff.
+    Exponential(ExponentialBackoff),
+}
+
+impl Backoff for BackoffPolicy {
+    fn next_backoff(&mut self) -> Option<Duration> {
+        match self {
+            BackoffPolicy::Stop => Stop {}.next_backoff(),
+            BackoffPolicy::Exponential(b) => b.next_backoff(),
+        }
+    }
+
+    fn reset(&mut self) {
+        match self {
+            BackoffPolicy::Stop => Stop {}.reset(),
+            BackoffPolicy::Exponential(b) => b.reset(),
+        }
+    }
+}
+
 /// A high-level client for interacting with Google BigTable using authenticated
 /// requests over gRPC.
 #[derive(Clone)]
@@ -101,7 +129,7 @@ pub struct BigTableClient {
     table_prefix: String,
     /// Prometheus metrics for tracking client performance.
     metrics: Option<Arc<Metrics>>,
-    backoff: ExponentialBackoff,
+    backoff: BackoffPolicy,
 }
 
 impl BigTableClient {
@@ -125,7 +153,7 @@ impl BigTableClient {
             client_name: "local".to_string(),
             column_family: column_family.into(),
             metrics: None,
-            backoff: Self::default_backoff(),
+            backoff: BackoffPolicy::Stop,
         })
     }
 
@@ -199,22 +227,21 @@ impl BigTableClient {
             client_name: client_name.into(),
             column_family: column_family.into(),
             metrics: registry.map(Metrics::new),
-            backoff: Self::default_backoff(),
+            backoff: BackoffPolicy::Stop,
         })
     }
 
-    /// Registers a custom backoff configuration template for the client
-    /// overwriting the default one.
+    /// Registers a custom backoff configuration template for the client.
     ///
     /// The backoff is used to control the retry behavior of the client for
     /// transient errors.
     pub fn with_backoff(mut self, backoff: ExponentialBackoff) -> Self {
-        self.backoff = backoff;
+        self.backoff = BackoffPolicy::Exponential(backoff);
         self
     }
 
     /// Returns the default backoff configuration template for the client.
-    fn default_backoff() -> ExponentialBackoff {
+    pub fn default_backoff() -> ExponentialBackoff {
         ExponentialBackoff {
             max_elapsed_time: Some(TRANSIENT_ERRORS_MAX_ELAPSED_TIME_SECS),
             initial_interval: Duration::from_millis(100),
@@ -223,12 +250,12 @@ impl BigTableClient {
         }
     }
 
-    /// Creates a new [`ExponentialBackoff`] instance based on the configured
+    /// Creates a new [`BackoffPolicy`] instance based on the configured
     /// template.
     ///
     /// Returns a fresh backoff instance that has been reset to its initial
     /// state, ensuring consistent retry behavior for each new operation.
-    pub(crate) fn backoff(&self) -> ExponentialBackoff {
+    fn backoff(&self) -> BackoffPolicy {
         let mut backoff = self.backoff.clone();
         backoff.reset();
         backoff

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,6 +117,12 @@ impl Backoff for BackoffPolicy {
 
 /// A high-level client for interacting with Google BigTable using authenticated
 /// requests over gRPC.
+///
+/// # Backoff on Transient Errors
+/// By default the client does **not** retry transient errors. Call
+/// [`with_backoff`](Self::with_backoff) to enable retries. Optionally, use
+/// [`default_backoff`](Self::default_backoff) to get a pre-configured backoff
+/// policy.
 #[derive(Clone)]
 pub struct BigTableClient {
     /// gRPC client for interacting with Google BigTable.
@@ -129,6 +135,7 @@ pub struct BigTableClient {
     table_prefix: String,
     /// Prometheus metrics for tracking client performance.
     metrics: Option<Arc<Metrics>>,
+    /// The backoff policy to use for transient errors.
     backoff: BackoffPolicy,
 }
 
@@ -231,16 +238,15 @@ impl BigTableClient {
         })
     }
 
-    /// Registers a custom backoff configuration template for the client.
+    /// Enables retrying of transient errors using the given backoff policy.
     ///
-    /// The backoff is used to control the retry behavior of the client for
-    /// transient errors.
+    /// By default the client performs no retries; call this to opt in.
     pub fn with_backoff(mut self, backoff: ExponentialBackoff) -> Self {
         self.backoff = BackoffPolicy::Exponential(backoff);
         self
     }
 
-    /// Returns the default backoff configuration template for the client.
+    /// Returns the default backoff configuration for the client.
     pub fn default_backoff() -> ExponentialBackoff {
         ExponentialBackoff {
             max_elapsed_time: Some(TRANSIENT_ERRORS_MAX_ELAPSED_TIME_SECS),

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use backoff::ExponentialBackoff;
 use gcp_auth::{Token, TokenProvider};
 use http::{HeaderValue, Request, Response};
 use prometheus::Registry;
@@ -20,7 +21,7 @@ use tonic::{
     Streaming,
     body::Body,
     codegen::Service,
-    transport::{Certificate, Channel, ClientTlsConfig},
+    transport::{Certificate, Channel, ClientTlsConfig, Endpoint},
 };
 
 use crate::{
@@ -43,6 +44,9 @@ const MAX_MUTATIONS_PER_MUTATE_ROWS_REQUEST: usize = 100_000;
 const BIGTABLE_POLICY: &str = "https://www.googleapis.com/auth/bigtable.data";
 const BIGTABLE_API: &str = "https://bigtable.googleapis.com";
 const BIGTABLE_DOMAIN: &str = "bigtable.googleapis.com";
+
+/// Maximum allowed number of connections in the connection pool.
+const POOL_SIZE: usize = 10;
 
 pub type Bytes = Vec<u8>;
 
@@ -164,19 +168,25 @@ impl BigTableClient {
             tls_config = tls_config.with_native_roots()
         };
 
-        let mut endpoint = Channel::from_static(BIGTABLE_API)
+        // Create a shared endpoint with keep-alive and TLS configuration.
+        let mut endpoint = Endpoint::from_static(BIGTABLE_API)
             .http2_keep_alive_interval(Duration::from_secs(60))
             .keep_alive_while_idle(true)
             .tls_config(tls_config)?;
         if let Some(timeout) = timeout {
             endpoint = endpoint.timeout(timeout);
         }
+
+        // Create a channel pool with the shared endpoint.
+        let endpoints = std::iter::repeat_n(endpoint, POOL_SIZE);
+        let channel_pool = Channel::balance_list(endpoints);
+
         let table_prefix = format!(
             "projects/{}/instances/{}/tables/",
             token_provider.project_id().await?,
             instance_id.as_ref()
         );
-        let auth_channel = AuthChannel::new_remote(endpoint.connect_lazy(), policy, token_provider);
+        let auth_channel = AuthChannel::new_remote(channel_pool, policy, token_provider);
         Ok(Self {
             table_prefix,
             client: BigtableInternalClient::new(auth_channel),
@@ -190,6 +200,22 @@ impl BigTableClient {
         format!("{}{table_name}", self.table_prefix)
     }
 
+    /// Retries the provided closure using an [`ExponentialBackoff`]
+    async fn with_retry<F, Fut, T, E>(f: F) -> std::result::Result<T, E>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = std::result::Result<T, backoff::Error<E>>>,
+    {
+        let backoff = ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_secs(2)),
+            initial_interval: Duration::from_millis(100),
+            multiplier: 1.2,
+            ..Default::default()
+        };
+
+        backoff::future::retry(backoff, f).await
+    }
+
     /// Mutates multiple rows in a batch. Each individual row is mutated
     /// atomically as in MutateRow, but the entire batch is not executed
     /// atomically.
@@ -200,8 +226,7 @@ impl BigTableClient {
         Ok(self.client.mutate_rows(request).await?.into_inner())
     }
 
-    /// Reads rows from Bigtable and returns their keys and cell values.
-    pub async fn read_rows(&mut self, request: ReadRowsRequest) -> Result<Vec<Row>> {
+    async fn read_rows_internal(&mut self, request: ReadRowsRequest) -> Result<Vec<Row>> {
         let mut rows = vec![];
         let mut response = self.client.read_rows(request).await?.into_inner();
 
@@ -255,6 +280,21 @@ impl BigTableClient {
             }
         }
         Ok(rows)
+    }
+
+    /// Reads rows from Bigtable and returns their keys and cell values.
+    ///
+    /// Applies backoff retries to handle transient errors.
+    pub async fn read_rows(&mut self, request: ReadRowsRequest) -> Result<Vec<Row>> {
+        Self::with_retry(|| async {
+            let request = request.clone();
+            let mut client = self.clone();
+            client
+                .read_rows_internal(request)
+                .await
+                .map_err(BigTableClientError::into_backoff_error)
+        })
+        .await
     }
 
     /// Sets multiple rows in Bigtable in a single batch operation.

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use backoff::ExponentialBackoff;
+use backoff::{ExponentialBackoff, backoff::Backoff};
 use gcp_auth::{Token, TokenProvider};
 use http::{HeaderValue, Request, Response};
 use prometheus::Registry;
@@ -47,6 +47,9 @@ const BIGTABLE_DOMAIN: &str = "bigtable.googleapis.com";
 
 /// Maximum allowed number of connections in the connection pool.
 const POOL_SIZE: usize = 10;
+
+/// The maximum allowed elapsed time in seconds for transient errors.
+const TRANSIENT_ERRORS_MAX_ELAPSED_TIME_SECS: Duration = Duration::from_secs(10);
 
 pub type Bytes = Vec<u8>;
 
@@ -98,6 +101,7 @@ pub struct BigTableClient {
     table_prefix: String,
     /// Prometheus metrics for tracking client performance.
     metrics: Option<Arc<Metrics>>,
+    backoff: ExponentialBackoff,
 }
 
 impl BigTableClient {
@@ -111,6 +115,7 @@ impl BigTableClient {
         let emulator_host = std::env::var("BIGTABLE_EMULATOR_HOST")?;
         let channel = Channel::from_shared(format!("http://{emulator_host}"))?.connect_lazy();
         let auth_channel = AuthChannel::new_localhost(channel, BIGTABLE_POLICY);
+
         Ok(Self {
             table_prefix: format!(
                 "projects/emulator/instances/{}/tables/",
@@ -120,6 +125,7 @@ impl BigTableClient {
             client_name: "local".to_string(),
             column_family: column_family.into(),
             metrics: None,
+            backoff: Self::default_backoff(),
         })
     }
 
@@ -193,27 +199,43 @@ impl BigTableClient {
             client_name: client_name.into(),
             column_family: column_family.into(),
             metrics: registry.map(Metrics::new),
+            backoff: Self::default_backoff(),
         })
+    }
+
+    /// Registers a custom backoff configuration template for the client
+    /// overwriting the default one.
+    ///
+    /// The backoff is used to control the retry behavior of the client for
+    /// transient errors.
+    pub fn with_backoff(mut self, backoff: ExponentialBackoff) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// Returns the default backoff configuration template for the client.
+    fn default_backoff() -> ExponentialBackoff {
+        ExponentialBackoff {
+            max_elapsed_time: Some(TRANSIENT_ERRORS_MAX_ELAPSED_TIME_SECS),
+            initial_interval: Duration::from_millis(100),
+            multiplier: 1.2,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new [`ExponentialBackoff`] instance based on the configured
+    /// template.
+    ///
+    /// Returns a fresh backoff instance that has been reset to its initial
+    /// state, ensuring consistent retry behavior for each new operation.
+    pub(crate) fn backoff(&self) -> ExponentialBackoff {
+        let mut backoff = self.backoff.clone();
+        backoff.reset();
+        backoff
     }
 
     fn table_name(&self, table_name: &str) -> String {
         format!("{}{table_name}", self.table_prefix)
-    }
-
-    /// Retries the provided closure using an [`ExponentialBackoff`]
-    async fn with_retry<F, Fut, T, E>(f: F) -> std::result::Result<T, E>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output = std::result::Result<T, backoff::Error<E>>>,
-    {
-        let backoff = ExponentialBackoff {
-            max_elapsed_time: Some(Duration::from_secs(2)),
-            initial_interval: Duration::from_millis(100),
-            multiplier: 1.2,
-            ..Default::default()
-        };
-
-        backoff::future::retry(backoff, f).await
     }
 
     /// Mutates multiple rows in a batch. Each individual row is mutated
@@ -286,7 +308,7 @@ impl BigTableClient {
     ///
     /// Applies backoff retries to handle transient errors.
     pub async fn read_rows(&mut self, request: ReadRowsRequest) -> Result<Vec<Row>> {
-        Self::with_retry(|| async {
+        backoff::future::retry(self.backoff(), || async {
             let request = request.clone();
             let mut client = self.clone();
             client

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,12 +27,13 @@ pub enum BigTableClientError {
 }
 
 impl BigTableClientError {
-    /// Converts this error into a [`backoff::Error`].
-    pub(crate) fn into_backoff_error(self) -> backoff::Error<Self> {
+    /// Returns `true` if the error is permanent one and is not subject to
+    /// transient retries, `false` otherwise.
+    pub(crate) fn is_permantent(&self) -> bool {
         use tonic::Code::*;
 
-        if let BigTableClientError::Grpc(status) = &self
-            && matches!(
+        if let BigTableClientError::Grpc(status) = &self {
+            return !matches!(
                 status.code(),
                 Cancelled
                     | Aborted
@@ -41,18 +42,14 @@ impl BigTableClientError {
                     | Unavailable
                     | DeadlineExceeded
                     | ResourceExhausted
-            )
-        {
-            return backoff::Error::transient(self);
+            );
         }
 
         // we don't have access to the error kind, so we use the error message instead.
-        if let BigTableClientError::GrpcTransport(e) = &self
-            && e.to_string().contains("transport error")
-        {
-            return backoff::Error::transient(self);
+        if let BigTableClientError::GrpcTransport(e) = &self {
+            return !e.to_string().contains("transport error");
         }
 
-        backoff::Error::permanent(self)
+        true
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,3 +25,34 @@ pub enum BigTableClientError {
     #[error("io error: `{0}`")]
     Io(#[from] std::io::Error),
 }
+
+impl BigTableClientError {
+    /// Converts this error into a [`backoff::Error`].
+    pub(crate) fn into_backoff_error(self) -> backoff::Error<Self> {
+        use tonic::Code::*;
+
+        if let BigTableClientError::Grpc(status) = &self
+            && matches!(
+                status.code(),
+                Cancelled
+                    | Aborted
+                    | Internal
+                    | Unknown
+                    | Unavailable
+                    | DeadlineExceeded
+                    | ResourceExhausted
+            )
+        {
+            return backoff::Error::transient(self);
+        }
+
+        // we don't have access to the error kind, so we use the error message instead.
+        if let BigTableClientError::GrpcTransport(e) = &self
+            && e.to_string().contains("transport error")
+        {
+            return backoff::Error::transient(self);
+        }
+
+        backoff::Error::permanent(self)
+    }
+}


### PR DESCRIPTION
# Description of change

This PR improves robustness against transient errors in the gRPC communication between the client and the Google BigTable server. BigTable periodically recycles long-lived connections (idle timeout, ~hourly lifecycle, or GOAWAY). The client previously had no retry, so any in-flight requests on a recycled connection failed and surfaced as dropped queries (HTTP 500s) to callers.

Following the official Go BigTable client, we now retry a specific set of transient gRPC errors with exponential backoff. Retries are scoped to the read path (`read_rows`, and therefore `multi_get` and `range_scan`), which is idempotent; writes (mutate_rows) are intentionally not retried, since they use server-assigned timestamps and are not idempotent, matching the Go client's behavior.

The retryable set covers the codes a connection reset surfaces as in tonic/hyper/h2: `Unavailable`, `DeadlineExceeded`, `Aborted`, `ResourceExhausted`, `Cancelled`, `Internal`, `Unknown`, plus transport-level errors.

We also added a simple connection pool of 10 channels (tonic `Channel::balance_list`) to reduce errors that could be caused on heavy load by using only a single connection reset. Channels are lazily initialized, so additional connections are only opened as demand increases, under low traffic only a few are live.

## Links to any relevant issues

fixes [#11978](https://github.com/iotaledger/iota/issues/11978)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran locally on mainnet the iota-rest-kv with updated bigtable, ensuring the added connection pool didn't cause any unwanted behavior.
- Checked that backoff was triggered correctly.
- Was not able to receive the errors which in first place started this issue since BigTable connection reset can happen randomly.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.