### PR TITLE
refactor!: `new_local` method signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bigtable"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "backoff",
  "gcp_auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-bigtable"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["IOTA Foundation <info@iota.org>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -143,12 +143,31 @@ impl BigTableClient {
     /// Creates a new BigTableClient instance for a local instance using the
     /// emulator feature. It reads the emulator host from the
     /// `BIGTABLE_EMULATOR_HOST` environment variable.
-    pub async fn new_local(
+    pub fn new_local(
         instance_id: impl AsRef<str>,
         column_family: impl Into<String>,
     ) -> Result<Self> {
         let emulator_host = std::env::var("BIGTABLE_EMULATOR_HOST")?;
-        let channel = Channel::from_shared(format!("http://{emulator_host}"))?.connect_lazy();
+        Self::new_local_with_host(emulator_host, "local", instance_id, column_family)
+    }
+
+    /// Creates a new BigTableClient instance for a local instance using the
+    /// emulator feature.
+    ///
+    /// Unlike [`new_local`](Self::new_local), the emulator host is passed
+    /// explicitly instead of being read from the `BIGTABLE_EMULATOR_HOST`
+    /// environment variable, and the client name (used for logging and metrics)
+    /// can be customized.
+    ///
+    /// `host` is expected in `host:port` form without a scheme (e.g.
+    /// `127.0.0.1:8086`), the client then connects over plain HTTP.
+    pub fn new_local_with_host(
+        host: impl AsRef<str>,
+        client_name: impl Into<String>,
+        instance_id: impl AsRef<str>,
+        column_family: impl Into<String>,
+    ) -> Result<Self> {
+        let channel = Channel::from_shared(format!("http://{}", host.as_ref()))?.connect_lazy();
         let auth_channel = AuthChannel::new_localhost(channel, BIGTABLE_POLICY);
 
         Ok(Self {
@@ -157,7 +176,7 @@ impl BigTableClient {
                 instance_id.as_ref()
             ),
             client: BigtableInternalClient::new(auth_channel),
-            client_name: "local".to_string(),
+            client_name: client_name.into(),
             column_family: column_family.into(),
             metrics: None,
             backoff: BackoffPolicy::Stop,

--- a/src/client.rs
+++ b/src/client.rs
@@ -141,27 +141,11 @@ pub struct BigTableClient {
 
 impl BigTableClient {
     /// Creates a new BigTableClient instance for a local instance using the
-    /// emulator feature. It reads the emulator host from the
-    /// `BIGTABLE_EMULATOR_HOST` environment variable.
-    pub fn new_local(
-        instance_id: impl AsRef<str>,
-        column_family: impl Into<String>,
-    ) -> Result<Self> {
-        let emulator_host = std::env::var("BIGTABLE_EMULATOR_HOST")?;
-        Self::new_local_with_host(emulator_host, "local", instance_id, column_family)
-    }
-
-    /// Creates a new BigTableClient instance for a local instance using the
     /// emulator feature.
-    ///
-    /// Unlike [`new_local`](Self::new_local), the emulator host is passed
-    /// explicitly instead of being read from the `BIGTABLE_EMULATOR_HOST`
-    /// environment variable, and the client name (used for logging and metrics)
-    /// can be customized.
     ///
     /// `host` is expected in `host:port` form without a scheme (e.g.
     /// `127.0.0.1:8086`), the client then connects over plain HTTP.
-    pub fn new_local_with_host(
+    pub fn new_local(
         host: impl AsRef<str>,
         client_name: impl Into<String>,
         instance_id: impl AsRef<str>,


### PR DESCRIPTION
# Description of change

This PR refactors `BigTableClient::new_local`, allowing the client to connect to a specific emulator host address directly.

**Motivation**:
Previously, the client relied solely on the `BIGTABLE_EMULATOR_HOST` environment variable. This caused significant flakiness in integration tests: because environment variables are shared process-wide, tests could not reliably connect to different emulator instances concurrently.

**The new method allows**:

- Explicit Host Configuration: Pass the host directly rather than relying on global state.
- Distinguishable Clients: You can now provide a custom client name (replacing the hardcoded "local"), which improves visibility in logs and metrics.

**Refactor Details**:
- ⚠️ Breaking Change:
The async qualifier has been removed from `new_local`, as the initialization process performs no asynchronous work. Callers must remove the `.await` from their existing `new_local(...)` calls.

## Links to any relevant issues

fixes #14 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)